### PR TITLE
Replace unrar with unrar-free in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
-    unrar \
+    unrar-free \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory


### PR DESCRIPTION
The current python:3.12-slim image does not have the unrar package in its default repositories which causes the Docker build to fail. Switching to unrar-free ensures the image builds successfully on fresh deployments.