### PR TITLE
Fix UUID handling when using Postgres 18 alpine on docker

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -51,8 +51,12 @@ class GUID(TypeDecorator):
 
     def process_result_value(self, value, dialect):
         if value is None:
+            return None
+    
+        if isinstance(value, uuid.UUID):
             return value
-        return uuid.UUID(value)
+    
+        return uuid.UUID(str(value))
 
 
 class JSONType(TypeDecorator):


### PR DESCRIPTION
This change is a fix for the UUID accessing error on Postgres 18 alpine to safely access the UUID

Stacktrace:

ERROR:app:Exception on request GET /dashboard 2026-07-03T17:06:09.998571038Z Traceback (most recent call last): 2026-07-03T17:06:09.998574253Z File "/usr/local/lib/python3.12/site-packages/quart/app.py", line 1464, in handle_request 2026-07-03T17:06:09.998576919Z return await self.full_dispatch_request(request_context) 2026-07-03T17:06:09.998579273Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998581587Z File "/usr/local/lib/python3.12/site-packages/quart/app.py", line 1502, in full_dispatch_request 2026-07-03T17:06:09.998584052Z result = await self.handle_user_exception(error) 2026-07-03T17:06:09.998586637Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998588871Z File "/usr/local/lib/python3.12/site-packages/quart/app.py", line 1059, in handle_user_exception 2026-07-03T17:06:09.998591237Z raise error 2026-07-03T17:06:09.998593451Z File "/usr/local/lib/python3.12/site-packages/quart/app.py", line 1500, in full_dispatch_request 2026-07-03T17:06:09.998595765Z result = await self.dispatch_request(request_context) 2026-07-03T17:06:09.998598019Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998600273Z File "/usr/local/lib/python3.12/site-packages/quart/app.py", line 1597, in dispatch_request 2026-07-03T17:06:09.998602608Z return await self.ensure_async(handler)(**request_.view_args) # type: ignore[return-value] 2026-07-03T17:06:09.998605022Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998607326Z File "/usr/local/lib/python3.12/site-packages/quart_auth/globals.py", line 64, in wrapper 2026-07-03T17:06:09.998609681Z return await current_app.ensure_async(func)(*args, **kwargs) 2026-07-03T17:06:09.998611925Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998614169Z File "/app/app/routes/main.py", line 51, in dashboard 2026-07-03T17:06:09.998616484Z result = await session.execute( 2026-07-03T17:06:09.998618678Z ^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998631363Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/ext/asyncio/session.py", line 449, in execute 2026-07-03T17:06:09.998634960Z result = await greenlet_spawn( 2026-07-03T17:06:09.998638436Z ^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998642374Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 203, in greenlet_spawn 2026-07-03T17:06:09.998651902Z result = context.switch(value) 2026-07-03T17:06:09.998656049Z ^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998660327Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2351, in execute 2026-07-03T17:06:09.998664004Z return self._execute_internal( 2026-07-03T17:06:09.998667250Z ^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998672500Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2249, in _execute_internal 2026-07-03T17:06:09.998676699Z result: Result[Any] = compile_state_cls.orm_execute_statement( 2026-07-03T17:06:09.998680486Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998683843Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/context.py", line 309, in orm_execute_statement 2026-07-03T17:06:09.998687058Z return cls.orm_setup_cursor_result( 2026-07-03T17:06:09.998690204Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998693180Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/context.py", line 616, in orm_setup_cursor_result 2026-07-03T17:06:09.998695574Z return loading.instances(result, querycontext) 2026-07-03T17:06:09.998708288Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998710533Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 262, in instances 2026-07-03T17:06:09.998712846Z _prebuffered = list(chunks(None)) 2026-07-03T17:06:09.998715032Z ^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998717216Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 220, in chunks 2026-07-03T17:06:09.998719540Z fetch = cursor._raw_all_rows() 2026-07-03T17:06:09.998721724Z ^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998723938Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/result.py", line 553, in _raw_all_rows 2026-07-03T17:06:09.998726303Z return [make_row(row) for row in rows] 2026-07-03T17:06:09.998728918Z ^^^^^^^^^^^^^ 2026-07-03T17:06:09.998731162Z File "lib/sqlalchemy/cyextension/resultproxy.pyx", line 22, in sqlalchemy.cyextension.resultproxy.BaseRow.__init__ 2026-07-03T17:06:09.998733537Z File "lib/sqlalchemy/cyextension/resultproxy.pyx", line 79, in sqlalchemy.cyextension.resultproxy._apply_processors 2026-07-03T17:06:09.998735901Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/sql/type_api.py", line 2169, in process 2026-07-03T17:06:09.998744006Z return fixed_process_value(value, dialect) 2026-07-03T17:06:09.998746300Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998748525Z File "/app/app/models.py", line 55, in process_result_value 2026-07-03T17:06:09.998750849Z return uuid.UUID(value) 2026-07-03T17:06:09.998753103Z ^^^^^^^^^^^^^^^^ 2026-07-03T17:06:09.998755357Z File "/usr/local/lib/python3.12/uuid.py", line 175, in __init__ 2026-07-03T17:06:09.998757633Z hex = hex.replace('urn:', '').replace('uuid:', '') 2026-07-03T17:06:09.998759877Z ^^^^^^^^^^^ 2026-07-03T17:06:09.998762071Z AttributeError: 'asyncpg.pgproto.pgproto.UUID' object has no attribute 'replace' 2026-07-03T17:06:12.553778447Z ERROR:app:Exception on request GET /dashboard 2026-07-03T17:06:12.553821628Z Traceback (most recent call last): 2026-07-03T17:06:12.553825706Z File "/usr/local/lib/python3.12/site-packages/quart/app.py", line 1464, in handle_request 2026-07-03T17:06:12.553829163Z return await self.full_dispatch_request(request_context) 2026-07-03T17:06:12.553832218Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553835234Z File "/usr/local/lib/python3.12/site-packages/quart/app.py", line 1502, in full_dispatch_request 2026-07-03T17:06:12.553838381Z result = await self.handle_user_exception(error) 2026-07-03T17:06:12.553841337Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553844934Z File "/usr/local/lib/python3.12/site-packages/quart/app.py", line 1059, in handle_user_exception 2026-07-03T17:06:12.553848720Z raise error 2026-07-03T17:06:12.553852287Z File "/usr/local/lib/python3.12/site-packages/quart/app.py", line 1500, in full_dispatch_request 2026-07-03T17:06:12.553855513Z result = await self.dispatch_request(request_context) 2026-07-03T17:06:12.553858749Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553862236Z File "/usr/local/lib/python3.12/site-packages/quart/app.py", line 1597, in dispatch_request 2026-07-03T17:06:12.553865572Z return await self.ensure_async(handler)(**request_.view_args) # type: ignore[return-value] 2026-07-03T17:06:12.553868748Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553871744Z File "/usr/local/lib/python3.12/site-packages/quart_auth/globals.py", line 64, in wrapper 2026-07-03T17:06:12.553875090Z return await current_app.ensure_async(func)(*args, **kwargs) 2026-07-03T17:06:12.553878167Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553881082Z File "/app/app/routes/main.py", line 51, in dashboard 2026-07-03T17:06:12.553884028Z result = await session.execute( 2026-07-03T17:06:12.553886943Z ^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553906870Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/ext/asyncio/session.py", line 449, in execute 2026-07-03T17:06:12.553910498Z result = await greenlet_spawn( 2026-07-03T17:06:12.553916349Z ^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553919896Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 203, in greenlet_spawn 2026-07-03T17:06:12.553923373Z result = context.switch(value) 2026-07-03T17:06:12.553926308Z ^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553929243Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2351, in execute 2026-07-03T17:06:12.553932349Z return self._execute_internal( 2026-07-03T17:06:12.553935115Z ^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553939092Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2249, in _execute_internal 2026-07-03T17:06:12.553942408Z result: Result[Any] = compile_state_cls.orm_execute_statement( 2026-07-03T17:06:12.553945353Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553948510Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/context.py", line 309, in orm_execute_statement 2026-07-03T17:06:12.553951525Z return cls.orm_setup_cursor_result( 2026-07-03T17:06:12.553956435Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553959981Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/context.py", line 616, in orm_setup_cursor_result 2026-07-03T17:06:12.553963489Z return loading.instances(result, querycontext) 2026-07-03T17:06:12.553966405Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553969380Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 262, in instances 2026-07-03T17:06:12.553972826Z _prebuffered = list(chunks(None)) 2026-07-03T17:06:12.553975752Z ^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553978547Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 220, in chunks 2026-07-03T17:06:12.553981683Z fetch = cursor._raw_all_rows() 2026-07-03T17:06:12.553984468Z ^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.553987294Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/result.py", line 553, in _raw_all_rows 2026-07-03T17:06:12.553990509Z return [make_row(row) for row in rows] 2026-07-03T17:06:12.553993916Z ^^^^^^^^^^^^^ 2026-07-03T17:06:12.553997132Z File "lib/sqlalchemy/cyextension/resultproxy.pyx", line 22, in sqlalchemy.cyextension.resultproxy.BaseRow.__init__ 2026-07-03T17:06:12.554000188Z File "lib/sqlalchemy/cyextension/resultproxy.pyx", line 79, in sqlalchemy.cyextension.resultproxy._apply_processors 2026-07-03T17:06:12.554003485Z File "/usr/local/lib/python3.12/site-packages/sqlalchemy/sql/type_api.py", line 2169, in process 2026-07-03T17:06:12.554011239Z return fixed_process_value(value, dialect) 2026-07-03T17:06:12.554014145Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.554016990Z File "/app/app/models.py", line 55, in process_result_value 2026-07-03T17:06:12.554019986Z return uuid.UUID(value) 2026-07-03T17:06:12.554022781Z ^^^^^^^^^^^^^^^^ 2026-07-03T17:06:12.554025727Z File "/usr/local/lib/python3.12/uuid.py", line 175, in __init__ 2026-07-03T17:06:12.554029634Z hex = hex.replace('urn:', '').replace('uuid:', '') 2026-07-03T17:06:12.554032690Z ^^^^^^^^^^^ 2026-07-03T17:06:12.554035845Z AttributeError: 'asyncpg.pgproto.pgproto.UUID' object has no attribute 'replace'